### PR TITLE
Handle correctly last net + robustness

### DIFF
--- a/removenet.py
+++ b/removenet.py
@@ -1,15 +1,57 @@
-import sys
+#!/usr/bin/env python3
 
-net_found = False
-search_name = "(name {})".format(sys.argv[3])
+import sys
+import re
+
+def create_net_start_re(netname):
+  net_start_re = r'\(net\s+(\(code\s+[0-9]+\)\s+)?\(name\s+"{netname_re}"|{netname_re}\)'.format(netname_re=re.escape(netname))
+  return re.compile(net_start_re)
+
+net_start_re = create_net_start_re(sys.argv[3])
+node_re = re.compile(r'^\s*\(node\s+\(ref \w+\)\s+\(pin\s+\d+\)\s*\)(\)?)(.*)$')
+
+def test_re():
+  net_start_re = create_net_start_re('Net-(Q2-Pad2)')
+  assert net_start_re.search('    (net (code 34) (name "Net-(Q2-Pad2)")')
+  net_start_re = create_net_start_re('/LG1')
+  assert net_start_re.search('(net (code 32) (name /LG1)')
+
+  m = node_re.match("      (node (ref Q3) (pin 2))")
+  assert m
+  assert m[1] == ""
+  assert m[2] == ""
+  m = node_re.match("      (node (ref R22) (pin 2)))")
+  assert m
+  assert m[1] == ")"
+  assert m[2] == ""
+  m = node_re.match("      (node (ref J10) (pin 37)))))")
+  assert m
+  assert m[1] == ")"
+  assert m[2] == "))"
+
+test_re()
 
 with open(sys.argv[1]) as search:
-    with open(sys.argv[2],'w') as output:
-        for line in search:
-            tmpline = line.lstrip()  # remove '\n' at end of line
-            if tmpline.startswith("(net") and search_name in tmpline:
-                net_found = True
-            if tmpline.startswith("(net") and not search_name in tmpline:
-                net_found = False
-            if not net_found:
-                output.write(line)
+  with open(sys.argv[2], 'w') as output:
+    net_found = False
+    for line in search:
+      tmpline = line.strip()
+      if net_found:
+        m = node_re.match(tmpline)
+        if m:
+          # Output any suffix after the match, if any.
+          # This is to handle the case of matching the last net in file.
+          # which require us to output closing ))), which are likely on the
+          # same line.
+          closing = m.group(1)
+          if closing:
+            net_found = False
+          suffix = m.group(2)
+          if suffix:
+            output.write(suffix + "\n")
+          continue
+      net_found = False
+      if net_start_re.search(tmpline):
+        net_found = True
+        continue
+      output.write(line)


### PR DESCRIPTION
If the netname is matching the last net in the file, the output will be incorrect, and miss the closing '))'.

This patch fixes this. It doesn't use the start of a new net as the only signal of the end of nodes in the net.
A closing parentheses of a node list, will trigger it too.

The performance should be slightly better, not that it really matters.

It also now handled netnames that are in the netlist file in double quotes, which often KiCad do.

Add a sh-bang, as well minor indent format changes.

Add small test for regexps.

For example removing net `/R11` from the `test.net` file, now produces correct end of file:


```patch
--- test.net	2020-11-05 04:30:40.529961483 +0000
+++ test-without-r11.net	2020-11-05 10:21:52.870154384 +0000
@@ -642,8 +642,4 @@
       (node (ref R25) (pin 2))
       (node (ref J8) (pin 4))
       (node (ref J10) (pin 36)))
-    (net (code 42) (name /R11)
-      (node (ref J8) (pin 3))
-      (node (ref R28) (pin 1))
-      (node (ref R27) (pin 2))
-      (node (ref J10) (pin 37)))))
\ No newline at end of file
+))
```
